### PR TITLE
Add TCO Monte Carlo prediction service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # IT Financials SaaS
 
 This repository contains a small prototype for an IT financial management SaaS platform. The backend is built with FastAPI and SQLAlchemy.
+\nThe service layer now includes a Monte Carlo simulator for forecasting future TCO based on historical spend.

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,8 @@
+"""Service layer for data processing utilities."""
+from .allocation import allocate_costs
+from .prediction import monte_carlo_tco
+
+__all__ = [
+    "allocate_costs",
+    "monte_carlo_tco",
+]

--- a/backend/app/services/prediction.py
+++ b/backend/app/services/prediction.py
@@ -1,0 +1,57 @@
+"""TCO prediction utilities."""
+from __future__ import annotations
+
+import random
+from typing import Iterable, List
+
+import pandas as pd
+
+
+def monte_carlo_tco(
+    history: Iterable[float],
+    years: int,
+    iterations: int = 1000,
+    seed: int | None = None,
+) -> pd.DataFrame:
+    """Run Monte Carlo simulation to forecast future TCO.
+
+    Parameters
+    ----------
+    history:
+        Historical TCO values ordered chronologically.
+    years:
+        Number of future years to forecast.
+    iterations:
+        How many simulation runs to perform.
+    seed:
+        Optional random seed for reproducible results.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with shape ``(iterations, years)`` containing simulated
+        TCO values for each future year.
+    """
+    hist = list(history)
+    if seed is not None:
+        random.seed(seed)
+    if len(hist) < 2:
+        raise ValueError("Need at least two historical observations")
+
+    growth_rates: List[float] = [
+        (cur - prev) / prev for prev, cur in zip(hist, hist[1:])
+    ]
+    mu = sum(growth_rates) / len(growth_rates)
+    sigma = (sum((g - mu) ** 2 for g in growth_rates) / len(growth_rates)) ** 0.5
+
+    results = pd.DataFrame(
+        index=range(iterations), columns=range(1, years + 1), dtype=float
+    )
+    last_cost = hist[-1]
+    for i in range(iterations):
+        cost = last_cost
+        for year in range(1, years + 1):
+            growth = random.gauss(mu, sigma)
+            cost *= 1 + growth
+            results.at[i, year] = cost
+    return results

--- a/backend/tests/test_prediction.py
+++ b/backend/tests/test_prediction.py
@@ -1,0 +1,8 @@
+from app.services.prediction import monte_carlo_tco
+
+
+def test_monte_carlo_shape():
+    history = [100, 110, 105]
+    df = monte_carlo_tco(history, years=2, iterations=5, seed=42)
+    assert df.shape == (5, 2)
+    assert not df.isnull().any().any()


### PR DESCRIPTION
## Summary
- add `monte_carlo_tco` Monte Carlo model to forecast TCO
- expose new service via `app.services` package
- test that the Monte Carlo function works
- document new capability in README

## Testing
- `pre-commit run --files backend/app/services/prediction.py backend/app/services/__init__.py backend/tests/test_prediction.py README.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841b78a85ac832fb9a045d79d9aab35