### PR TITLE
Add Excel import endpoint

### DIFF
--- a/backend/app/routers/costs.py
+++ b/backend/app/routers/costs.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, File, UploadFile
 from sqlalchemy.orm import Session
 
 from .. import models, schemas
+from ..services import allocation, excel_import
 from ..dependencies import get_db
 
 router = APIRouter()
@@ -10,3 +11,18 @@ router = APIRouter()
 @router.get("/", response_model=list[schemas.CostEntryOut])
 def list_costs(db: Session = Depends(get_db)):
     return db.query(models.CostEntry).all()
+
+
+@router.post("/import-excel", response_model=list[schemas.CostEntryOut])
+def import_costs_from_excel(
+    file: UploadFile = File(...), db: Session = Depends(get_db)
+):
+    """Import cost entries from an uploaded Excel file."""
+    df = excel_import.load_spend_from_excel(file.file)
+    entries = allocation.allocate_costs(df)
+    for entry in entries:
+        db.add(entry)
+    db.commit()
+    for entry in entries:
+        db.refresh(entry)
+    return entries

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,2 @@
+from .allocation import allocate_costs
+from .excel_import import load_spend_from_excel

--- a/backend/app/services/excel_import.py
+++ b/backend/app/services/excel_import.py
@@ -1,0 +1,9 @@
+from typing import BinaryIO
+
+import pandas as pd
+from pandas import DataFrame
+
+
+def load_spend_from_excel(file: BinaryIO) -> DataFrame:
+    """Load raw spend data from an Excel file into a DataFrame."""
+    return pd.read_excel(file)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 sqlalchemy
 pydantic
 pandas
+openpyxl

--- a/backend/tests/test_excel_import.py
+++ b/backend/tests/test_excel_import.py
@@ -1,0 +1,18 @@
+from io import BytesIO
+
+import pandas as pd
+
+from app.services.excel_import import load_spend_from_excel
+
+
+def test_load_spend_from_excel():
+    df = pd.DataFrame({"application_id": ["123"], "amount": [10.0]})
+    buf = BytesIO()
+    df.to_excel(buf, index=False)
+    buf.seek(0)
+
+    loaded = load_spend_from_excel(buf)
+
+    assert list(loaded.columns) == ["application_id", "amount"]
+    assert loaded.shape == (1, 2)
+    assert float(loaded.loc[0, "amount"]) == 10.0


### PR DESCRIPTION
## Summary
- update requirements to include openpyxl
- add helper service to load Excel files with pandas
- expose new `/import-excel` endpoint in costs router
- test Excel loading service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b7d8dbb4832f9cfff2b40c3b53ba